### PR TITLE
fix: fix resource limits for stability

### DIFF
--- a/k8s/iris-runner-pod-manager.yml
+++ b/k8s/iris-runner-pod-manager.yml
@@ -22,12 +22,8 @@ spec:
         ports:
         - containerPort: 8080
         resources:
-          limits:
-            cpu: "0.5"
-            memory: "512Mi"
           requests:
-            cpu: "0.2"
-            memory: "200Mi"
+            cpu: "0.5"
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/pod-manager/pod-manager.go
+++ b/k8s/pod-manager/pod-manager.go
@@ -57,12 +57,11 @@ func (pm *PodManager) createRunnerPod() (*RunnerPod, error) {
                     },
                     Resources: corev1.ResourceRequirements{
                         Limits: corev1.ResourceList{
-                            corev1.ResourceCPU:    resource.MustParse("0.5"),
-                            corev1.ResourceMemory: resource.MustParse("512Mi"),
+                            corev1.ResourceMemory: resource.MustParse("512Mi")
                         },
                         Requests: corev1.ResourceList{
-                            corev1.ResourceCPU:    resource.MustParse("0.2"),
-                            corev1.ResourceMemory: resource.MustParse("200Mi"),
+                            corev1.ResourceCPU:    resource.MustParse("0.5"),
+                            corev1.ResourceMemory: resource.MustParse("512Mi"),
                         },
                     },
                 },


### PR DESCRIPTION
https://d2.naver.com/helloworld/7248350

위의 테크블로그를 읽고 Iris-Runner 쿠버네티스 리소스 제한을 수정합니다.

1. Iris-Runner 는 latency 가 중요하므로 CPU 사용량 제한(hard limit)을 설정하지 않습니다.
2. requests.memory 와 limits.memory 값을 같게 설정함으로써 예기치 못한 OOM 예방합니다. 
    - “두 값을 다르게 한다고 자원을 아껴 쓸 수 있는 것은 아닙니다” - 테크블로그
    - requests 값 ~ limits 값  사이의 구간은 불안정합니다. 예기치 못한 OOM 발생 가능.