### PR TITLE
fix: disable buffering in C and C++

### DIFF
--- a/backend/compile_opts.go
+++ b/backend/compile_opts.go
@@ -19,12 +19,12 @@ var CompileOptions = map[string]CompileOption{
 	C: {
 		Filename:   "/code/main.c",
 		CompileCmd: []string{"/usr/bin/gcc", "-o", "/code/main", "/code/main.c"},
-		ExecuteCmd: []string{"/code/main"},
+		ExecuteCmd: []string{"/usr/bin/stdbuf", "-o0", "/code/main"},
 	},
 	CPP: {
 		Filename:   "/code/main.cpp",
 		CompileCmd: []string{"/usr/bin/g++", "-o", "/code/main", "/code/main.cpp"},
-		ExecuteCmd: []string{"/code/main"},
+		ExecuteCmd: []string{"/usr/bin/stdbuf", "-o0", "/code/main"},
 	},
 	JAVA: {
 		Filename:   "/code/Main.java",


### PR DESCRIPTION
## 문제 정의

다음과 같이 작성된 C 언어 코드에서, 출력 순서가 의도한 대로 동작하지 않는 문제가 발생합니다.

```jsx
#include <stdio.h>

int main()
{
  printf("hello");
  int num;
  printf("입력해줘: ");
  scanf("%d", &num);
  
  printf("결과 %d", num);
}
```

이 코드는  [ hello, 입력해줘: ] 의 내용이 출력된 이후에 사용자 입력을 받는 것이 의도이지만, **실제 실행 시에는** **입력 대기 상태에 먼저 진입합니다.**

## 문제 분석

C 언어에서 printf() 함수는 내부적으로 buffer 를 사용하여 출력합니다. 이 버퍼링 방식은 **Line Buffering**이라 불리며, 아래 조건 중 하나가 충족될 때 버퍼가 비워지며 출력됩니다:

1. 개행 문자( \n )를 만났을 때
2. 버퍼가 가득 찼을 때
3. 명시적으로 버퍼를 flush했을 때 ( fllush(stdout) )

즉, 다음 코드처럼 개행 문자가 없고 버퍼가 flush되지 않은 경우, 사용자는 `printf("입력해줘: ");`의 출력 결과를 보지 못한 채 `scanf()`의 입력 대기 상태로 진입할 수 있습니다.

## 해결
C와 C++ 을 실행할 시 출력 버퍼링을 비활성화합니다.

## Testing
### 해결 전
"hello 입력하줘:" 출력값 이전에 입력해야 되는 상황. (입력값 34343434)
<img width="590" alt="image" src="https://github.com/user-attachments/assets/e405761e-6324-4145-b4dc-8b60aefadb7a" />


### 해결 후
"hello 입력해줘:" 출력값 이후에 입력  (입력값 34343434)
<img width="590" alt="image" src="https://github.com/user-attachments/assets/aeec8e0a-b781-46c3-bf36-10ac490b03c4" />



