### PR TITLE
feat: secure runner with HTTPS and WSS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
       - "443:443"
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     network_mode: host
+
   frontend:
     image: ghcr.io/skkuding/iris-runner-frontend:latest
     container_name: iris-runner-frontend

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -170,7 +170,7 @@
           onDataDisposable.dispose();
         }
 
-        ws = new WebSocket(`ws://${location.host}/run`);
+        ws = new WebSocket(`wss://${location.host}/run`);
         term.writeln("[시스템] 실행 서버에 연결을 시도합니다...");
 
         ws.onopen = () => {

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,8 +1,18 @@
 server {
     listen 80;
-    # TODO: Change to codedang domain later.
-    server_name _;
+    server_name run.codedang.com;
+    return 301 https://$server_name$request_uri;
+}
 
+server {
+    listen 443 ssl;
+    server_name run.codedang.com;
+
+    ssl_certificate /etc/letsencrypt/live/run.codedang.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/run.codedang.com/privkey.pem;
+
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
     # Root path to frontend
     location / {
         proxy_pass http://localhost:3000;
@@ -23,7 +33,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         
-        # 10분 타임아웃 설정
+        # timeout 10 minutes
         proxy_read_timeout 600;
         proxy_send_timeout 600;
         proxy_connect_timeout 60s;


### PR DESCRIPTION
## 문제 정의
현재 codedang 서비스는 HTTPS 기반으로 운영되고 있습니다. 그러나 연동되는 마이크로서비스인 codedang-runner 는 여전히 HTTP로 동작 중이기에 codedang 서비스에 연동을 하면 Mixed Content 오류가 발생합니다. 이 오류를 해결하고자 HTTPS 를 적용합니다. 
웹소켓 연결 또한 ws 가 아닌 wss 프로토콜을 사용하도록 전환이 필요합니다.

### 해결
1. 5번 서버(온프레미스)에 Certbot 설치 및 Let's Encrypt 를 통해 인증서 발급
2. NGINX 설정 수정

### 특이사항
URL 은 https://run.codedang.com/ 으로 수정합니다.

### Testing
개인 EC2 실험 환경
- (상단) https://codedang-runner.my 접속 가능
- (우측 하단) wss://codedang-runner.my/run 으로 호출
<img width="1627" alt="image" src="https://github.com/user-attachments/assets/d878a638-a566-40e8-be86-07a6bb2117d1" />
