### PR TITLE
fix: disable SSL redirect in Ingress configuration

### DIFF
--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -4,6 +4,7 @@ metadata:
   name: iris-runner
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-dns01" # 학교 네트워크 특성상(HTTP-01을 위한 80번 포트 사용 불가) DNS-01 사용
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600" # RUN 특성 고려하여 10분으로 조정
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "30" # 원본 요청 정보 유지


### PR DESCRIPTION
## Problem and Solution
코드당 레포와는 다르게 이 서비스는 앞 단의 Docker compose 레벨에서 인증서를 처리합니다.
임시로 minikube 내의 cert manager를 통해 재발급 받은 인증서를 복사 붙여넣기 해서 수동으로 인증서를 갱신했습니다.

## Additional Context
하지만 여기서 걸리는 게 왜 앞단에 프록시 Docker compose 레벨을 추가했는지 이유를 확인해야 할 것 같습니다.(@jimin9038)
개인적인 생각으로는 프론트/백엔드 서비스 모두 Docker compose 레벨 생략하고 코드당 본 레포에 통합하여 쿠버네티스 레벨에서 관리하는 것이 좋아 보입니다.